### PR TITLE
Fix encoding

### DIFF
--- a/click_log/core.py
+++ b/click_log/core.py
@@ -41,7 +41,9 @@ class ColorFormatter(logging.Formatter):
                                      **self.colors[level])
 
                 msg = record.msg
-                if not isinstance(record.msg, (bytes, text_type)):
+                if isinstance(record.msg, bytes):
+                    msg = msg.decode()
+                elif not isinstance(record.msg, text_type):
                     msg = str(msg)
                 record.msg = '\n'.join(prefix + x for x in msg.splitlines())
 


### PR DESCRIPTION
Fix the following message in case the input is of type `bytes`:

```
TypeError: Can't convert 'bytes' object to str implicitly
```

Also, directly converting it in string will result into the following output: `debug: b'my content'`. Running `decode` will properly convert the `bytes` to a string.