### PR TITLE
Allow specifying custom formatter and log level in init decorator

### DIFF
--- a/click_log/__init__.py
+++ b/click_log/__init__.py
@@ -3,7 +3,7 @@
 
 import click
 
-__version__ = '0.1.8'
+__version__ = '0.1.8-tomers'
 
 
 if not hasattr(click, 'get_current_context'):

--- a/click_log/core.py
+++ b/click_log/core.py
@@ -65,28 +65,36 @@ class ClickHandler(logging.Handler):
 
 
 _default_handler = ClickHandler()
-_default_handler.formatter = ColorFormatter()
 
 
-def basic_config(logger=None):
+def basic_config(logger=None, formatter=None):
     '''Set up the default handler (:py:class:`ClickHandler`) and formatter
     (:py:class:`ColorFormatter`) on the given logger.'''
     if not isinstance(logger, logging.Logger):
         logger = logging.getLogger(logger)
+    if formatter is None:
+        _default_handler.formatter = ColorFormatter()
+    else:
+        _default_handler.formatter = formatter
+
     logger.handlers = [_default_handler]
     logger.propagate = False
 
     return logger
 
 
-def init(logger=None):
+def init(logger=None, formatter=None, level=None):
     '''Set the application's logger and call :py:func:`basic_config` on it.'''
     def decorator(f):
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
             m = _meta()
-            l = basic_config(logger=logger)
-            l.setLevel(m.get('level', DEFAULT_LEVEL))
+            l = basic_config(logger=logger, formatter=formatter)
+            if level is None:
+                log_level = m.get('level', DEFAULT_LEVEL)
+            else:
+                log_level = level
+            l.setLevel(log_level)
 
             if m.setdefault('logger', l) is not l:
                 raise RuntimeError('Only one main logger allowed.')

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -76,3 +76,49 @@ def test_weird_types_log(runner):
     result = runner.invoke(cli, catch_exceptions=False)
     assert not result.exception
     assert result.output == 'error: 42\n' * 4
+
+
+def test_formatter(runner):
+    formatter = logging.Formatter(fmt='%(levelname)s | %(message)s')
+
+    @click.command()
+    @click_log.init(formatter=formatter)
+    def cli():
+        test_logger.debug('hey')
+        test_logger.info('yo')
+        test_logger.warning('oh')
+        test_logger.error('damn')
+
+    result = runner.invoke(cli, catch_exceptions=False)
+    assert not result.exception
+    assert result.output == 'INFO | yo\nWARNING | oh\nERROR | damn\n'
+
+
+def test_level(runner):
+    @click.command()
+    @click_log.init(level=logging.WARNING)
+    def cli():
+        test_logger.debug('hey')
+        test_logger.info('yo')
+        test_logger.warning('oh')
+        test_logger.error('damn')
+
+    result = runner.invoke(cli, catch_exceptions=False)
+    assert not result.exception
+    assert result.output == 'warning: oh\nerror: damn\n'
+
+
+def test_level_with_formatter(runner):
+    formatter = logging.Formatter(fmt='%(levelname)s | %(message)s')
+
+    @click.command()
+    @click_log.init(level=logging.WARNING, formatter=formatter)
+    def cli():
+        test_logger.debug('hey')
+        test_logger.info('yo')
+        test_logger.warning('oh')
+        test_logger.error('damn')
+
+    result = runner.invoke(cli, catch_exceptions=False)
+    assert not result.exception
+    assert result.output == 'WARNING | oh\nERROR | damn\n'


### PR DESCRIPTION
Hi,
I wanted to add support for explicitly defining formatter and logging level during declaration of the logger in the @init decorator.
I added unit-tests for this new feature.
I wanted to update documentation (of http://click.pocoo.org/dev/api/) accordingly, but unfortunately it seems that the documentation code is not part of the GitHub project.
I would appreciate if you could merge this code.

Thanks