### PR TITLE
Operate on the default logger by default

### DIFF
--- a/click_log/options.py
+++ b/click_log/options.py
@@ -4,7 +4,7 @@ import click
 from .core import _normalize_logger
 
 
-def simple_verbosity_option(logger, *names, **kwargs):
+def simple_verbosity_option(logger=None, *names, **kwargs):
     '''A decorator that adds a `--verbosity, -v` option to the decorated
     command.
 


### PR DESCRIPTION
`basic_config` operates on the default logger by default. Implement the
same behaviour for `simple_verbosity_option`, so that both can be called
with no arguments when the root logger should be used.

Closes #9 