### PR TITLE
core.ColorFormatter: add 'info' to colors dict

### DIFF
--- a/click_log/core.py
+++ b/click_log/core.py
@@ -28,6 +28,7 @@ class ColorFormatter(logging.Formatter):
         'exception': dict(fg='red'),
         'critical': dict(fg='red'),
         'debug': dict(fg='blue'),
+        'info': dict(fg='white'),
         'warning': dict(fg='yellow')
     }
 


### PR DESCRIPTION
see https://docs.python.org/3/library/logging.html#logging-levels

Not sure about how to trigger loglevel 'exception', though…