### PR TITLE
Add trailing dot to help text

### DIFF
--- a/click_log/options.py
+++ b/click_log/options.py
@@ -21,7 +21,8 @@ def simple_verbosity_option(logger=None, *names, **kwargs):
     kwargs.setdefault('default', 'INFO')
     kwargs.setdefault('metavar', 'LVL')
     kwargs.setdefault('expose_value', False)
-    kwargs.setdefault('help', 'Either CRITICAL, ERROR, WARNING, INFO or DEBUG')
+    kwargs.setdefault('help',
+                      'Either CRITICAL, ERROR, WARNING, INFO or DEBUG.')
     kwargs.setdefault('is_eager', True)
 
     logger = _normalize_logger(logger)


### PR DESCRIPTION
Click’s built-in help texts, such as `--help` or `--version`, are all written with a trailing a dot.

Thanks,

James