### PR TITLE
Make newline optional

### DIFF
--- a/click_log/core.py
+++ b/click_log/core.py
@@ -50,7 +50,12 @@ class ClickHandler(logging.Handler):
         try:
             msg = self.format(record)
             level = record.levelname.lower()
-            click.echo(msg, err=self._use_stderr)
+            newline = True
+
+            if hasattr(record, 'nl'):
+                newline = record.nl;
+
+            click.echo(msg, nl=newline, err=self._use_stderr)
         except Exception:
             self.handleError(record)
 


### PR DESCRIPTION
Allow users to control newline behaviour by defining the `nl` key in the
`extra` dictionary. E.g.

```python
logger.info('Some task...', extra={'nl': False})
```

would not print a newline at the end of `Some task...`. After the task
the user could run

```python
logger.info('Done.')
```

yielding a complete output of

```bash
Some task...Done.
```