### PR TITLE
Add `@verbosity_option` decorator

### DIFF
--- a/click_log/__init__.py
+++ b/click_log/__init__.py
@@ -15,4 +15,4 @@ from .core import (
     basic_config,
 )
 
-from .options import simple_verbosity_option
+from .options import simple_verbosity_option, verbosity_option

--- a/click_log/options.py
+++ b/click_log/options.py
@@ -81,16 +81,16 @@ def verbosity_option(logger=None, *names, **kwargs):
     kwargs.setdefault("default", "INFO")
     kwargs.setdefault("metavar", "[LOGGER=]LEVEL[,...]")
     kwargs.setdefault("expose_value", False)
-    kwargs.setdefault("help", f"A {SYNTAX_DESC}.")
+    kwargs.setdefault("help", "A %s." % (SYNTAX_DESC,))
     kwargs.setdefault("is_eager", True)
 
     logger = _normalize_logger(logger)
 
     def decorator(f):
-        def _set_log_levels(_ctx, _param, value: str):
+        def _set_log_levels(_ctx, _param, value):
             for item in value.split(","):
                 try:
-                    name, level = item.split("=", maxsplit=1)
+                    name, level = item.split("=", 1)
                     target_logger = logger.getChild(name)
                 except ValueError:
                     level = item
@@ -98,7 +98,7 @@ def verbosity_option(logger=None, *names, **kwargs):
 
                 logging_level = getattr(logging, level.upper(), None)
                 if logging_level is None:
-                    raise click.BadParameter(f"Must be a {SYNTAX_DESC}, not {{}}")
+                    raise click.BadParameter("Must be a %s, not {}" % SYNTAX_DESC)
 
                 target_logger.setLevel(logging_level)
 

--- a/click_log/options.py
+++ b/click_log/options.py
@@ -36,4 +36,72 @@ def simple_verbosity_option(logger=None, *names, **kwargs):
             logger.setLevel(x)
 
         return click.option(*names, callback=_set_level, **kwargs)(f)
+
+    return decorator
+
+
+def verbosity_option(logger=None, *names, **kwargs):
+    """A decorator that adds a `--verbosity, -v` option to the decorated
+    command, allowing to configure log levels of a logger and its
+    child-loggers.
+
+    If for example::
+
+    .. code-block:: python
+
+        from logging import getLogger
+        from click import command
+        from click_log import verbosity_option
+
+        @command
+        @verbosity_option(getLogger('foo'))
+        def command():
+            pass
+
+    is called via
+
+    .. code-block:: sh
+
+        $ ./script.py -v WARNING,bar=DEBUG
+
+    the logger `'foo'` is set to level WARNING, but its child logger `'foo.bar'`
+    will still log messages with level DEBUG.
+
+    Name can be configured through ``*names``. Keyword arguments are passed to
+    the underlying ``click.option`` decorator.
+
+    :param logger: logging.Logger
+        Logger instance for which log levels are set.
+    :param names: str
+        Option names (default: `['-v', '--verbose']`)
+    """
+    if not names:
+        names = ["-v", "--verbose"]
+    SYNTAX_DESC = "comma-separated list of [LOGGER=]LEVEL assignments, where LEVEL is one of CRITICAL, ERROR, WARNING, INFO or DEBUG"
+    kwargs.setdefault("default", "INFO")
+    kwargs.setdefault("metavar", "[LOGGER=]LEVEL[,...]")
+    kwargs.setdefault("expose_value", False)
+    kwargs.setdefault("help", f"A {SYNTAX_DESC}.")
+    kwargs.setdefault("is_eager", True)
+
+    logger = _normalize_logger(logger)
+
+    def decorator(f):
+        def _set_log_levels(_ctx, _param, value: str):
+            for item in value.split(","):
+                try:
+                    name, level = item.split("=", maxsplit=1)
+                    target_logger = logger.getChild(name)
+                except ValueError:
+                    level = item
+                    target_logger = logger
+
+                logging_level = getattr(logging, level.upper(), None)
+                if logging_level is None:
+                    raise click.BadParameter(f"Must be a {SYNTAX_DESC}, not {{}}")
+
+                target_logger.setLevel(logging_level)
+
+        return click.option(*names, callback=_set_log_levels, **kwargs)(f)
+
     return decorator

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -103,3 +103,20 @@ def test_logging_args(runner):
 
     result = runner.invoke(cli, ['-v', 'debug'])
     assert 'debug: hello world' in result.output
+
+
+def test_logging_complex_args(runner):
+    spammy_logger = test_logger.getChild("spam")
+    child_logger = spammy_logger.getChild("child")
+
+    @click.command()
+    @click_log.verbosity_option(test_logger)
+    def cli():
+        test_logger.debug("normal debug message")
+        spammy_logger.debug("spammy message")
+        child_logger.debug("interesting message")
+
+    result = runner.invoke(cli, ["-v", "debug,spam=info,spam.child=debug"])
+    assert "debug: normal debug message" in result.output
+    assert "debug: spammy message" not in result.output
+    assert "debug: interesting message" in result.output


### PR DESCRIPTION
Hi, I use `click_log` for an application with many logger instances, each of which outputs a lot of debug information.  To make debugging a single component easier, I implemented a custom decorator `@verbosity_option` that makes it possible to silence parts of the application. 

Is this a feature that would be useful to have in `click_log`?  Naming is up for debate and documentation can surely be improved. Also I'm not quite sure what the minimum python version is that should be supported (I used `f`-strings and maybe some other "new" features in there).

Below is the commit message for this pull request:

This decorator is intended for complex applications which have multiple nested logger instances. It can be used to selectivly toggle log levels for loggers and their child loggers.  A use case for this would be when one has a large application that has a detailed debug output across its modules.  When debugging a single module, one wants to silence debug output of all modules except for this one.

Imagine an application with multiple logger instance such as this:

```python
from logging import getLogger
from click import command
from click_log import verbosity_option, basic_config

app_logger = getLogger(__name__)

# imagine these are loggers in submodules, using python's
# hierarchical logger naming scheme
foo_logger = getLogger(__name__ + ".foo")
bar_logger = getLogger(__name__ + ".bar")

basic_config(app_logger)

@command()
@verbosity_option(app_logger)
def main():
    app_logger.info("Hello world from App")
    foo_logger.debug("Do foo-stuff")
    bar_logger.debug("Frobnicating doobles in bar")

if __name__ == "__main__":
    main()
```

The verbosity options provided by this decorator take a comma-separated list of `<LOGGER>=<LEVEL>` assignments (which set levels for child loggers of the `app_logger`) or `<LEVEL>` statements (which set the verbosity of `app_logger` itself).  Running

```sh
$ ./script.py -v INFO,foo=DEBUG
```

then prints

```
Hello world from App
debug: Do foo-stuff
```

Notice how the output of `bar_logger` was supressed, as python loggers inherit their log level from their parent loggers; in this case `app_logger`.

This decorator is a drop-in replacement for `@simple_verbosity_option`; supplying `-v <LEVEL>` does exactly the same for both decorators.