### PR TITLE
Add missing string interpolation in error message.

### DIFF
--- a/click_log/options.py
+++ b/click_log/options.py
@@ -32,6 +32,7 @@ def simple_verbosity_option(logger=None, *names, **kwargs):
             if x is None:
                 raise click.BadParameter(
                     'Must be CRITICAL, ERROR, WARNING, INFO or DEBUG, not {}'
+                    ''.format(value)
                 )
             logger.setLevel(x)
 

--- a/click_log/options.py
+++ b/click_log/options.py
@@ -32,7 +32,7 @@ def simple_verbosity_option(logger=None, *names, **kwargs):
             if x is None:
                 raise click.BadParameter(
                     'Must be CRITICAL, ERROR, WARNING, INFO or DEBUG, not {}'
-                    ''.format(value)
+                    .format(value)
                 )
             logger.setLevel(x)
 


### PR DESCRIPTION
The default error message is not printing the bad verbosity level value:
```
$ cli --verbosity BLAH
Usage: cli [OPTIONS]...

Error: Invalid value for '--verbosity' / '-v': Must be CRITICAL, ERROR, WARNING, INFO or DEBUG, not {}
```

This PR fix this issue.